### PR TITLE
Delete redundant assignment

### DIFF
--- a/2-Data Structures/Week6-Binary Search Trees/4-splay tree.py
+++ b/2-Data Structures/Week6-Binary Search Trees/4-splay tree.py
@@ -124,7 +124,6 @@ def merge(left, right):
         right = right.left
     right = splay(right)
     right.left = left
-    left.parent = right # starter file里忘掉了
     update(right)  # important!!
     return right
 


### PR DESCRIPTION
The line marked as "Forgot in starter file" is actually not necessary because the subsequent `update()` function does the exact same job